### PR TITLE
[ESP-IDF5.1] Add support for ESP-IDF 5.1 (ESP32 Arduino 3.0)

### DIFF
--- a/src/Servo.cpp
+++ b/src/Servo.cpp
@@ -33,4 +33,6 @@
 // Implementation is in Servo.h
 #include <Servo.h>
 
+#if ESP_IDF_VERSION_MAJOR < 5
 int ServoBase::channel_next_free = 0;
+#endif

--- a/src/Servo.h
+++ b/src/Servo.h
@@ -36,6 +36,10 @@
 
 #include "Arduino.h"
 
+#if ESP_IDF_VERSION_MAJOR >= 5
+#include <driver/ledc.h>
+#endif
+
 class ServoBase {
    protected:
     // The main purpose of ServoBase is to make sure that multiple instances of
@@ -65,8 +69,12 @@ class ServoTemplate : public ServoBase {
 
     static const int DEFAULT_FREQUENCY = 50;
 
-    static const int TIMER_RESOLUTION = std::min(16, SOC_LEDC_TIMER_BIT_WIDE_NUM);
-    static const int PERIOD_TICKS = (1 << TIMER_RESOLUTION) - 1;
+#if ESP_IDF_VERSION_MAJOR >= 5
+    static constexpr int TIMER_RESOLUTION = (16 < SOC_LEDC_TIMER_BIT_WIDTH) ? 16 : SOC_LEDC_TIMER_BIT_WIDTH;
+#else
+    static constexpr int TIMER_RESOLUTION = (16 < SOC_LEDC_TIMER_BIT_WIDE_NUM) ? 16 : SOC_LEDC_TIMER_BIT_WIDE_NUM; //   std::min(16, SOC_LEDC_TIMER_BIT_WIDE_NUM);
+#endif
+    static constexpr int PERIOD_TICKS = (1 << TIMER_RESOLUTION) - 1;
 
     static const int CHANNEL_NOT_ATTACHED = -1;
 
@@ -128,6 +136,7 @@ class ServoTemplate : public ServoBase {
         if (tempPeriodUs <= maxPulseWidthUs) {
             return false;
         }
+#if ESP_IDF_VERSION_MAJOR < 5
         if (channel == CHANNEL_NOT_ATTACHED) {
             if (channel_next_free == LEDC_CHANNELS) {
                 return false;
@@ -137,6 +146,7 @@ class ServoTemplate : public ServoBase {
         } else {
             _channel = channel;
         }
+#endif
 
         _pin = pin;
         _minAngle = minAngle;
@@ -145,8 +155,12 @@ class ServoTemplate : public ServoBase {
         _maxPulseWidthUs = maxPulseWidthUs;
         _periodUs = tempPeriodUs;
 
+#if ESP_IDF_VERSION_MAJOR < 5
         ledcSetup(_channel, frequency, TIMER_RESOLUTION);
         ledcAttachPin(_pin, _channel);
+#else
+        ledcAttach(_pin, frequency, TIMER_RESOLUTION);
+#endif
         return true;
     }
 
@@ -161,11 +175,14 @@ class ServoTemplate : public ServoBase {
         if (!this->attached()) {
             return false;
         }
-
+#if ESP_IDF_VERSION_MAJOR < 5
         if (_channel == (channel_next_free - 1))
             channel_next_free--;
 
         ledcDetachPin(_pin);
+#else
+        ledcDetach(_pin);
+#endif
         _pin = PIN_NOT_ATTACHED;
         return true;
     }
@@ -200,7 +217,11 @@ class ServoTemplate : public ServoBase {
         }
         pulseWidthUs = constrain(pulseWidthUs, _minPulseWidthUs, _maxPulseWidthUs);
         _pulseWidthTicks = _usToTicks(pulseWidthUs);
+#if ESP_IDF_VERSION_MAJOR < 5
         ledcWrite(_channel, _pulseWidthTicks);
+#else
+        ledcWrite(_pin, _pulseWidthTicks);
+#endif
     }
 
     /**
@@ -221,7 +242,11 @@ class ServoTemplate : public ServoBase {
         if (!this->attached()) {
             return 0;
         }
-        int duty = ledcRead(_channel);
+#if ESP_IDF_VERSION_MAJOR < 5
+        const int duty = ledcRead(_channel);
+#else
+        const int duty = ledcRead(_pin);
+#endif
         return _ticksToUs(duty);
     }
 
@@ -244,7 +269,9 @@ class ServoTemplate : public ServoBase {
     void _resetFields(void) {
         _pin = PIN_NOT_ATTACHED;
         _pulseWidthTicks = 0;
+#if ESP_IDF_VERSION_MAJOR < 5
         _channel = CHANNEL_NOT_ATTACHED;
+#endif
         _minAngle = DEFAULT_MIN_ANGLE;
         _maxAngle = DEFAULT_MAX_ANGLE;
         _minPulseWidthUs = DEFAULT_MIN_PULSE_WIDTH_US;
@@ -270,7 +297,9 @@ class ServoTemplate : public ServoBase {
 
     int _pin;
     int _pulseWidthTicks;
+#if ESP_IDF_VERSION_MAJOR < 5
     int _channel;
+#endif
     int _minPulseWidthUs, _maxPulseWidthUs;
     T _minAngle, _maxAngle;
     int _periodUs;


### PR DESCRIPTION
In ESP-IDF 5 the structure of peripheral drivers has been changed. Some functions have been merged/renamed and you no longer need to keep track of what channel is used.